### PR TITLE
Add simple React frontend with .NET backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # gitemergency
+
+This repository contains a minimal e-commerce site built with a React front-end and a .NET backend.
+
+The `/frontend` folder provides a simple React application that loads React from a CDN. Open `index.html` in a browser to view the site.
+
+The `/backend` folder contains a skeleton .NET Web API with basic authentication support.

--- a/backend/Gitemergency.sln
+++ b/backend/Gitemergency.sln
@@ -1,0 +1,9 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShopApi", "ShopApi/ShopApi.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Global
+EndGlobal

--- a/backend/ShopApi/Program.cs
+++ b/backend/ShopApi/Program.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net.Http.Headers;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAuthentication("Basic")
+    .AddScheme<AuthenticationSchemeOptions, BasicAuthHandler>("Basic", null);
+
+builder.Services.AddAuthorization();
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapGet("/", () => "Welcome to the Simple Shop API!")
+    .RequireAuthorization();
+
+app.Run();
+
+public class BasicAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public BasicAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ISystemClock clock)
+        : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.ContainsKey("Authorization"))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Missing Authorization Header"));
+        }
+
+        AuthenticationHeaderValue authHeader;
+        try
+        {
+            authHeader = AuthenticationHeaderValue.Parse(Request.Headers["Authorization"]);
+        }
+        catch
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Invalid Authorization Header"));
+        }
+
+        var credentialBytes = Convert.FromBase64String(authHeader.Parameter ?? string.Empty);
+        var credentials = Encoding.UTF8.GetString(credentialBytes).Split(':', 2);
+        if (credentials.Length != 2)
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Invalid Authorization Header"));
+        }
+
+        var username = credentials[0];
+        var password = credentials[1];
+
+        if (username != "admin" || password != "password")
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Invalid Username or Password"));
+        }
+
+        var claims = new[] { new Claim(ClaimTypes.Name, username) };
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/backend/ShopApi/ShopApi.csproj
+++ b/backend/ShopApi/ShopApi.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -1,0 +1,23 @@
+function App() {
+  const [message, setMessage] = React.useState('');
+
+  React.useEffect(() => {
+    fetch('http://localhost:5000/', {
+      headers: {
+        'Authorization': 'Basic ' + btoa('admin:password')
+      }
+    })
+    .then(res => res.text())
+    .then(setMessage)
+    .catch(err => setMessage('Error: ' + err));
+  }, []);
+
+  return (
+    <div>
+      <h1>Simple Shop</h1>
+      <p>{message}</p>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Simple Shop</title>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="text/babel" src="app.jsx"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create React app with sample API call
- add .NET Web API with basic authentication handler
- update README with brief project description

## Testing
- `npm test --silent` (fails silently, no test script)
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c8361ae08333a5fe86be70fcb4fb