### PR TITLE
Add test infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+**/node_modules/

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ This repository contains a minimal e-commerce site built with a React front-end 
 The `/frontend` folder provides a simple React application that loads React from a CDN. Open `index.html` in a browser to view the site.
 
 The `/backend` folder contains a skeleton .NET Web API with basic authentication support.
+
+## Running Tests
+
+Frontend unit tests are written with Jest and React Testing Library. Backend tests use xUnit and the ASP.NET Core testing framework.

--- a/backend/ShopApi.Tests/HomeEndpointTests.cs
+++ b/backend/ShopApi.Tests/HomeEndpointTests.cs
@@ -1,0 +1,29 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace ShopApi.Tests
+{
+    public class HomeEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+    {
+        private readonly WebApplicationFactory<Program> _factory;
+
+        public HomeEndpointTests(WebApplicationFactory<Program> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task GetRoot_ReturnsWelcomeMessage()
+        {
+            using var client = _factory.CreateClient();
+            var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes("admin:password"));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+            var response = await client.GetAsync("/");
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.Equal("Welcome to the Simple Shop API!", body);
+        }
+    }
+}

--- a/backend/ShopApi.Tests/ShopApi.Tests.csproj
+++ b/backend/ShopApi.Tests/ShopApi.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ShopApi\ShopApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/backend/ShopApi/Program.cs
+++ b/backend/ShopApi/Program.cs
@@ -76,3 +76,5 @@ public class BasicAuthHandler : AuthenticationHandler<AuthenticationSchemeOption
         return Task.FromResult(AuthenticateResult.Success(ticket));
     }
 }
+
+public partial class Program { }

--- a/frontend/__tests__/app.test.jsx
+++ b/frontend/__tests__/app.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import App from '../app.jsx';
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    text: () => Promise.resolve('Welcome to the Simple Shop API!'),
+  })
+);
+
+test('renders welcome message from API', async () => {
+  render(<App />);
+  await waitFor(() => {
+    expect(screen.getByText('Welcome to the Simple Shop API!')).toBeInTheDocument();
+  });
+});

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -21,3 +21,6 @@ function App() {
 }
 
 ReactDOM.render(<App />, document.getElementById('root'));
+if (typeof module !== 'undefined') {
+  module.exports = App;
+}

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react'],
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.22.9",
+    "@babel/preset-react": "^7.22.5",
+    "@testing-library/react": "^14.0.0",
+    "babel-jest": "^29.6.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "jest": "^29.6.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add export for `App` and Jest test for React
- add ASP.NET xUnit test project for the API
- mention tests in README

## Testing
- `npm test --silent` *(fails: jest not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841caed9f6483339c16c0ace8d133ae